### PR TITLE
Add mandatory Supabase MFA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,14 +8,14 @@ Whenever you make or discover a relevant app change, update this file in the sam
 
 ## Project Shape
 
-NotelyTask is a Flutter/Dart notes app with Supabase-backed email/password accounts, Supabase sync, attachments, and a HydratedBloc offline cache.
+NotelyTask is a Flutter/Dart notes app with Supabase-backed email/password accounts, mandatory authenticator-app two-factor authentication, Supabase sync, attachments, and a HydratedBloc offline cache.
 
 The app does not use the old local-folder sync backend anymore. Notes sync to Supabase as one per-user note document/blob, not as one row per note. Attachments are stored separately in private Supabase Storage.
 
 ## Architecture Map
 
 - `lib/main.dart` initializes Flutter, optional Supabase config, HydratedBloc, app cubits, routes, and theme.
-- `AuthCubit` owns Supabase Auth session state, signup, login, logout, reset email, and password update.
+- `AuthCubit` owns Supabase Auth session state, signup, login, logout, reset email, password update, mandatory TOTP enrollment, and MFA verification.
 - `NotesCubit` owns local note mutations, HydratedBloc serialization, conflict prompts, encryption decisions, and requests to sync the note blob.
 - `SupabaseSyncCubit` owns sync loading/error/dirty state and calls the Supabase repository.
 - `SupabaseSyncRepository` is the low-level Supabase database and Storage access layer.
@@ -30,6 +30,7 @@ The app does not use the old local-folder sync backend anymore. Notes sync to Su
 - Supabase Storage bucket `note-attachments` stores attachment bytes under the signed-in user's id prefix.
 - Attachment metadata remains inside the note blob.
 - Local text edits should update immediately and mark remote sync dirty if Supabase write fails.
+- Cloud note and attachment access requires a Supabase `aal2` session; email/password-only `aal1` sessions must stay in the MFA gate and must not trigger sync.
 - First login/sync must preserve the local-versus-cloud conflict prompt instead of silently overwriting either side.
 - The missing-PIN decrypt prompt in `NotesCubit` must remain single-flight. Auth, home mount, settings, and native/widget paths can overlap sync requests, and only one decrypt dialog should appear.
 
@@ -49,6 +50,7 @@ The app does not use the old local-folder sync backend anymore. Notes sync to Su
 - Use the hosted Supabase project for backend work. Do not start or rely on a local Supabase stack unless the user explicitly changes this preference.
 - The Supabase CLI uses `SUPABASE_ACCESS_TOKEN` in the user's shell for remote operations.
 - Apply migrations only after linking the intended project; never commit service-role keys.
+- TOTP MFA must stay enabled in Supabase config, and note/document Storage RLS must keep requiring `auth.jwt()->>'aal' = 'aal2'` for the app's private data surfaces.
 - Email confirmation and password reset require Supabase Auth redirect URLs for `https://notelytask.dbilgin.com/auth-callback` and `com.omedacore.notelytask://auth-callback`.
 - Firebase Hosting uses project `deniz-bilgin`, hosting target `notelytask`, and site `notelytask-edd7f`.
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## What's this?
 
-NotelyTask is an easy to use note-taking application with email/password accounts, Supabase sync, attachments, and an offline local cache. Just open it, sign in, and start taking notes.
+NotelyTask is an easy to use note-taking application with email/password accounts, mandatory authenticator-app two-factor authentication, Supabase sync, attachments, and an offline local cache. Just open it, sign in, and start taking notes.
 
 ## How does it work?
 
-NotelyTask uses [hydrated_bloc](https://pub.dev/packages/hydrated_bloc) to keep a local offline cache of your notes. When you are signed in, the app syncs your note document to Supabase.
+NotelyTask uses [hydrated_bloc](https://pub.dev/packages/hydrated_bloc) to keep a local offline cache of your notes. When you are signed in and have completed two-factor authentication, the app syncs your note document to Supabase.
 
 The Supabase backend stores one note blob per user instead of splitting every note into separate relational rows. Attachments are stored separately in private Supabase Storage and referenced from the note blob metadata.
 
@@ -32,13 +32,16 @@ The remote backend schema lives in `supabase/migrations` and is pushed to the ho
 
 ### Authentication
 
-The initial auth flow supports:
+The auth flow supports:
 
 - Email/password signup
 - Email confirmation
 - Email/password login
+- Required authenticator-app two-factor authentication
 - Password reset by email
 - Sign out
+
+Cloud note and attachment access requires an `aal2` Supabase session. After email/password login, existing users must verify a TOTP code or set up an authenticator app before cloud sync starts.
 
 ### Encryption
 

--- a/lib/cubit/auth_cubit.dart
+++ b/lib/cubit/auth_cubit.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:notelytask/models/auth_state.dart';
 import 'package:notelytask/service/supabase_service.dart';
@@ -10,34 +11,36 @@ class AuthCubit extends Cubit<AuthState> {
     _initialise();
   }
 
-  StreamSubscription<AuthState>? _authSubscription;
+  StreamSubscription<dynamic>? _authSubscription;
+  int _mfaEvaluationId = 0;
 
   SupabaseClient? get _client => SupabaseConfig.client;
 
-  void _initialise() {
+  Future<void> _initialise() async {
     final client = _client;
     if (client == null) {
       emit(const AuthState.unconfigured());
       return;
     }
 
-    final currentUser = client.auth.currentUser;
-    emit(
-      currentUser == null
-          ? const AuthState.unauthenticated()
-          : AuthState.authenticated(user: currentUser),
-    );
+    await _safeRefreshMfaState();
 
-    _authSubscription = client.auth.onAuthStateChange.map((data) {
+    _authSubscription = client.auth.onAuthStateChange.listen((data) async {
       final user = data.session?.user;
       if (data.event == AuthChangeEvent.passwordRecovery && user != null) {
-        return AuthState.passwordRecovery(user: user);
+        emit(AuthState.passwordRecovery(user: user));
+        return;
       }
       if (user == null) {
-        return const AuthState.unauthenticated();
+        emit(const AuthState.unauthenticated());
+        return;
       }
-      return AuthState.authenticated(user: user);
-    }).listen(emit);
+      if (data.event == AuthChangeEvent.signedIn ||
+          data.event == AuthChangeEvent.userUpdated ||
+          data.event == AuthChangeEvent.mfaChallengeVerified) {
+        await _safeRefreshMfaState(refreshFactors: true);
+      }
+    });
   }
 
   Future<void> signUp({
@@ -67,6 +70,7 @@ class AuthCubit extends Cubit<AuthState> {
             email: email,
             password: password,
           );
+      await refreshMfaState(refreshFactors: true);
     });
   }
 
@@ -101,27 +105,276 @@ class AuthCubit extends Cubit<AuthState> {
         emit(const AuthState.unauthenticated());
         return;
       }
-      emit(
-        AuthState.authenticated(
-          user: user,
-          message: 'Password updated.',
-        ),
+      await refreshMfaState(
+        message: 'Password updated.',
+        refreshFactors: true,
       );
     });
   }
 
-  Future<void> _runAuthAction(Future<void> Function() action) async {
-    final previous = state;
-    emit(const AuthState.loading());
+  Future<void> refreshMfaState({
+    String? message,
+    bool refreshFactors = false,
+  }) async {
+    final evaluationId = ++_mfaEvaluationId;
+    final client = _requireClient();
+    final user = client.auth.currentUser;
+    if (user == null) {
+      emit(const AuthState.unauthenticated());
+      return;
+    }
+
+    final refreshedFactors =
+        refreshFactors ? await client.auth.mfa.listFactors() : null;
+    if (evaluationId != _mfaEvaluationId || isClosed) {
+      return;
+    }
+
+    final currentUser = client.auth.currentUser ?? user;
+    final allFactors = refreshedFactors?.all ?? currentUser.factors ?? [];
+    final verifiedTotp = refreshedFactors?.totp ?? _verifiedTotp(allFactors);
+    if (verifiedTotp.isEmpty) {
+      emit(
+        AuthState.mfaEnrollmentRequired(
+          user: currentUser,
+          mfaFactors: allFactors,
+          message: message,
+        ),
+      );
+      return;
+    }
+
+    final assurance = client.auth.mfa.getAuthenticatorAssuranceLevel();
+    if (assurance.currentLevel != AuthenticatorAssuranceLevels.aal2) {
+      emit(
+        AuthState.mfaVerificationRequired(
+          user: currentUser,
+          mfaFactors: verifiedTotp,
+          message: message,
+        ),
+      );
+      return;
+    }
+
+    emit(
+      AuthState.authenticated(
+        user: currentUser,
+        mfaFactors: verifiedTotp,
+        message: message,
+      ),
+    );
+  }
+
+  Future<void> _safeRefreshMfaState({
+    String? message,
+    bool refreshFactors = false,
+  }) async {
     try {
-      await action();
+      await refreshMfaState(
+        message: message,
+        refreshFactors: refreshFactors,
+      );
     } on AuthException catch (error) {
       emit(AuthState.unauthenticated(error: error.message));
     } catch (error) {
       emit(AuthState.unauthenticated(error: error.toString()));
     }
+  }
+
+  List<Factor> _verifiedTotp(List<Factor> factors) {
+    return factors
+        .where(
+          (factor) =>
+              factor.factorType == FactorType.totp &&
+              factor.status == FactorStatus.verified,
+        )
+        .toList();
+  }
+
+  Future<void> startRequiredTotpEnrollment() async {
+    final previous = state;
+    if (previous.status != AuthStatus.mfaEnrollmentRequired) {
+      return;
+    }
+    await _runAuthAction(() async {
+      final enrollment = await createTotpEnrollment();
+      emit(
+        AuthState.mfaEnrollmentRequired(
+          user: previous.user!,
+          mfaFactors: previous.mfaFactors,
+          mfaEnrollment: enrollment,
+        ),
+      );
+    }, loadingState: previous);
+  }
+
+  Future<AuthMfaEnrollment> createTotpEnrollment() async {
+    final response = await _requireClient().auth.mfa.enroll(
+          issuer: 'NotelyTask',
+          friendlyName: 'Authenticator app',
+        );
+    final totp = response.totp;
+    if (totp == null) {
+      throw const AuthException('Authenticator setup did not return a secret.');
+    }
+    return AuthMfaEnrollment(
+      factorId: response.id,
+      uri: totp.uri,
+      qrCode: totp.qrCode,
+      secret: totp.secret,
+    );
+  }
+
+  Future<void> verifyRequiredTotpEnrollment(String code) async {
+    final enrollment = state.mfaEnrollment;
+    if (enrollment == null) {
+      emit(
+        AuthState.mfaEnrollmentRequired(
+          user: state.user!,
+          mfaFactors: state.mfaFactors,
+          error: 'Authenticator setup is not ready yet.',
+        ),
+      );
+      return;
+    }
+    await _runAuthAction(() async {
+      await _requireClient().auth.mfa.challengeAndVerify(
+            factorId: enrollment.factorId,
+            code: code,
+          );
+      await refreshMfaState(
+        message: 'Two-factor authentication enabled.',
+        refreshFactors: true,
+      );
+    }, loadingState: state);
+  }
+
+  Future<void> verifyTotpCode(String code, {String? factorId}) async {
+    final selectedFactorId = factorId ??
+        state.mfaFactors
+            .where((factor) => factor.factorType == FactorType.totp)
+            .map((factor) => factor.id)
+            .firstOrNull;
+    if (selectedFactorId == null) {
+      emit(
+        AuthState.mfaEnrollmentRequired(
+          user: state.user!,
+          mfaFactors: state.mfaFactors,
+          error: 'Set up an authenticator app before verifying.',
+        ),
+      );
+      return;
+    }
+    await _runAuthAction(() async {
+      await _requireClient().auth.mfa.challengeAndVerify(
+            factorId: selectedFactorId,
+            code: code,
+          );
+      await refreshMfaState(refreshFactors: true);
+    }, loadingState: state);
+  }
+
+  Future<void> verifyAdditionalTotpEnrollment({
+    required AuthMfaEnrollment enrollment,
+    required String code,
+  }) async {
+    await _requireClient().auth.mfa.challengeAndVerify(
+          factorId: enrollment.factorId,
+          code: code,
+        );
+    await refreshMfaState(
+      message: 'Authenticator added.',
+      refreshFactors: true,
+    );
+  }
+
+  Future<void> cancelTotpEnrollment(AuthMfaEnrollment enrollment) async {
+    try {
+      await _requireClient().auth.mfa.unenroll(enrollment.factorId);
+      await refreshMfaState(refreshFactors: true);
+    } catch (_) {
+      await refreshMfaState(refreshFactors: true);
+    }
+  }
+
+  Future<void> unenrollFactor(String factorId) async {
+    final verifiedTotp = state.mfaFactors
+        .where(
+          (factor) =>
+              factor.factorType == FactorType.totp &&
+              factor.status == FactorStatus.verified,
+        )
+        .toList();
+    if (verifiedTotp.length <= 1) {
+      emit(
+        AuthState.authenticated(
+          user: state.user!,
+          mfaFactors: state.mfaFactors,
+          message: 'Add another authenticator before removing this one.',
+        ),
+      );
+      return;
+    }
+    await _runAuthAction(() async {
+      await _requireClient().auth.mfa.unenroll(factorId);
+      await refreshMfaState(
+        message: 'Authenticator removed.',
+        refreshFactors: true,
+      );
+    });
+  }
+
+  Future<void> _runAuthAction(
+    Future<void> Function() action, {
+    AuthState? loadingState,
+  }) async {
+    final previous = loadingState ?? state;
+    emit(
+      previous.status == AuthStatus.mfaEnrollmentRequired ||
+              previous.status == AuthStatus.mfaVerificationRequired
+          ? AuthState(
+              status: previous.status,
+              user: previous.user,
+              mfaFactors: previous.mfaFactors,
+              mfaEnrollment: previous.mfaEnrollment,
+            )
+          : const AuthState.loading(),
+    );
+    try {
+      await action();
+    } on AuthException catch (error) {
+      emit(_stateWithError(previous, error.message));
+    } catch (error) {
+      emit(_stateWithError(previous, error.toString()));
+    }
     if (state.status == AuthStatus.loading) {
       emit(previous);
+    }
+  }
+
+  AuthState _stateWithError(AuthState previous, String error) {
+    switch (previous.status) {
+      case AuthStatus.mfaEnrollmentRequired:
+        return AuthState.mfaEnrollmentRequired(
+          user: previous.user!,
+          mfaFactors: previous.mfaFactors,
+          mfaEnrollment: previous.mfaEnrollment,
+          error: error,
+        );
+      case AuthStatus.mfaVerificationRequired:
+        return AuthState.mfaVerificationRequired(
+          user: previous.user!,
+          mfaFactors: previous.mfaFactors,
+          error: error,
+        );
+      case AuthStatus.authenticated:
+        return AuthState.authenticated(
+          user: previous.user!,
+          mfaFactors: previous.mfaFactors,
+          message: error,
+        );
+      default:
+        return AuthState.unauthenticated(error: error);
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -139,8 +139,7 @@ class AuthGate extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocConsumer<AuthCubit, AuthState>(
       listener: (context, state) {
-        if (state.status == AuthStatus.authenticated ||
-            state.status == AuthStatus.passwordRecovery) {
+        if (state.status == AuthStatus.authenticated) {
           context.read<NotesCubit>().getAndUpdateLocalNotes(context: context);
         }
       },

--- a/lib/models/auth_state.dart
+++ b/lib/models/auth_state.dart
@@ -5,19 +5,42 @@ enum AuthStatus {
   unconfigured,
   loading,
   unauthenticated,
+  mfaEnrollmentRequired,
+  mfaVerificationRequired,
   authenticated,
   passwordRecovery,
+}
+
+class AuthMfaEnrollment extends Equatable {
+  final String factorId;
+  final String uri;
+  final String qrCode;
+  final String secret;
+
+  const AuthMfaEnrollment({
+    required this.factorId,
+    required this.uri,
+    required this.qrCode,
+    required this.secret,
+  });
+
+  @override
+  List<Object?> get props => [factorId, uri, qrCode, secret];
 }
 
 class AuthState extends Equatable {
   final AuthStatus status;
   final User? user;
+  final List<Factor> mfaFactors;
+  final AuthMfaEnrollment? mfaEnrollment;
   final String? error;
   final String? message;
 
   const AuthState({
     required this.status,
     this.user,
+    this.mfaFactors = const [],
+    this.mfaEnrollment,
     this.error,
     this.message,
   });
@@ -25,12 +48,16 @@ class AuthState extends Equatable {
   const AuthState.unconfigured()
       : status = AuthStatus.unconfigured,
         user = null,
+        mfaFactors = const [],
+        mfaEnrollment = null,
         error = null,
         message = null;
 
   const AuthState.loading()
       : status = AuthStatus.loading,
         user = null,
+        mfaFactors = const [],
+        mfaEnrollment = null,
         error = null,
         message = null;
 
@@ -38,28 +65,56 @@ class AuthState extends Equatable {
     this.error,
     this.message,
   })  : status = AuthStatus.unauthenticated,
-        user = null;
+        user = null,
+        mfaFactors = const [],
+        mfaEnrollment = null;
+
+  const AuthState.mfaEnrollmentRequired({
+    required this.user,
+    this.mfaFactors = const [],
+    this.mfaEnrollment,
+    this.error,
+    this.message,
+  }) : status = AuthStatus.mfaEnrollmentRequired;
+
+  const AuthState.mfaVerificationRequired({
+    required this.user,
+    required this.mfaFactors,
+    this.error,
+    this.message,
+  })  : status = AuthStatus.mfaVerificationRequired,
+        mfaEnrollment = null;
 
   const AuthState.authenticated({
     required this.user,
+    this.mfaFactors = const [],
     this.message,
   })  : status = AuthStatus.authenticated,
+        mfaEnrollment = null,
         error = null;
 
   const AuthState.passwordRecovery({
     required this.user,
     this.message,
   })  : status = AuthStatus.passwordRecovery,
+        mfaFactors = const [],
+        mfaEnrollment = null,
         error = null;
 
-  bool get isAuthenticated =>
-      status == AuthStatus.authenticated ||
-      status == AuthStatus.passwordRecovery;
+  bool get isAuthenticated => status == AuthStatus.authenticated;
+
+  bool get hasVerifiedTotp => mfaFactors.any(
+        (factor) =>
+            factor.factorType == FactorType.totp &&
+            factor.status == FactorStatus.verified,
+      );
 
   @override
   List<Object?> get props => [
         status,
         user?.id,
+        mfaFactors,
+        mfaEnrollment,
         error,
         message,
       ];

--- a/lib/screens/auth_callback_page.dart
+++ b/lib/screens/auth_callback_page.dart
@@ -4,6 +4,7 @@ import 'package:notelytask/cubit/auth_cubit.dart';
 import 'package:notelytask/models/auth_state.dart';
 import 'package:notelytask/screens/auth_page.dart';
 import 'package:notelytask/screens/home_page.dart';
+import 'package:notelytask/screens/mfa_page.dart';
 
 class AuthCallbackPage extends StatelessWidget {
   const AuthCallbackPage({super.key});
@@ -18,6 +19,11 @@ class AuthCallbackPage extends StatelessWidget {
 
         if (state.status == AuthStatus.passwordRecovery) {
           return const AuthPage();
+        }
+
+        if (state.status == AuthStatus.mfaEnrollmentRequired ||
+            state.status == AuthStatus.mfaVerificationRequired) {
+          return const MfaPage();
         }
 
         if (state.status == AuthStatus.unauthenticated ||

--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:notelytask/cubit/auth_cubit.dart';
 import 'package:notelytask/models/auth_state.dart';
+import 'package:notelytask/screens/mfa_page.dart';
 
 enum AuthFormMode { signIn, signUp, resetRequest, updatePassword }
 
@@ -38,6 +39,10 @@ class _AuthPageState extends State<AuthPage> {
       builder: (context, state) {
         if (state.status == AuthStatus.unconfigured) {
           return const _CloudConfigMissing();
+        }
+        if (state.status == AuthStatus.mfaEnrollmentRequired ||
+            state.status == AuthStatus.mfaVerificationRequired) {
+          return const MfaPage();
         }
 
         final theme = Theme.of(context);

--- a/lib/screens/mfa_page.dart
+++ b/lib/screens/mfa_page.dart
@@ -1,0 +1,366 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:notelytask/cubit/auth_cubit.dart';
+import 'package:notelytask/models/auth_state.dart';
+import 'package:pinput/pinput.dart';
+
+class MfaPage extends StatefulWidget {
+  const MfaPage({super.key});
+
+  @override
+  State<MfaPage> createState() => _MfaPageState();
+}
+
+class _MfaPageState extends State<MfaPage> {
+  bool _requestedEnrollment = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final state = context.read<AuthCubit>().state;
+    if (!_requestedEnrollment &&
+        state.status == AuthStatus.mfaEnrollmentRequired &&
+        state.mfaEnrollment == null) {
+      _requestedEnrollment = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          context.read<AuthCubit>().startRequiredTotpEnrollment();
+        }
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AuthCubit, AuthState>(
+      builder: (context, state) {
+        final isEnrollment = state.status == AuthStatus.mfaEnrollmentRequired;
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Two-factor authentication'),
+            actions: [
+              TextButton(
+                onPressed: () => context.read<AuthCubit>().signOut(),
+                child: const Text('Sign out'),
+              ),
+            ],
+          ),
+          body: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 460),
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      isEnrollment ? 'Secure your account' : 'Enter your code',
+                      style: Theme.of(context)
+                          .textTheme
+                          .headlineMedium
+                          ?.copyWith(fontWeight: FontWeight.w700),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      isEnrollment
+                          ? 'Two-factor authentication is required before your notes can sync.'
+                          : 'Open your authenticator app and enter the 6-digit code.',
+                    ),
+                    const SizedBox(height: 24),
+                    if (state.error != null) ...[
+                      Text(
+                        state.error!,
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.error,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                    ],
+                    if (state.message != null) ...[
+                      Text(
+                        state.message!,
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                    ],
+                    if (isEnrollment)
+                      state.mfaEnrollment == null
+                          ? _EnrollmentLoading(
+                              onRetry: () => context
+                                  .read<AuthCubit>()
+                                  .startRequiredTotpEnrollment(),
+                            )
+                          : MfaEnrollmentForm(
+                              enrollment: state.mfaEnrollment!,
+                              submitLabel: 'Enable and continue',
+                              onSubmit: (code) => context
+                                  .read<AuthCubit>()
+                                  .verifyRequiredTotpEnrollment(code),
+                            )
+                    else
+                      MfaChallengeForm(
+                        onSubmit: (code) =>
+                            context.read<AuthCubit>().verifyTotpCode(code),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class MfaEnrollmentDialog extends StatelessWidget {
+  const MfaEnrollmentDialog({
+    super.key,
+    required this.enrollment,
+  });
+
+  final AuthMfaEnrollment enrollment;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Add authenticator'),
+      content: SizedBox(
+        width: 420,
+        child: MfaEnrollmentForm(
+          enrollment: enrollment,
+          submitLabel: 'Verify authenticator',
+          onSubmit: (code) async {
+            await context.read<AuthCubit>().verifyAdditionalTotpEnrollment(
+                  enrollment: enrollment,
+                  code: code,
+                );
+            if (context.mounted) {
+              Navigator.of(context).pop(true);
+            }
+          },
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+}
+
+class MfaEnrollmentForm extends StatefulWidget {
+  const MfaEnrollmentForm({
+    super.key,
+    required this.enrollment,
+    required this.submitLabel,
+    required this.onSubmit,
+  });
+
+  final AuthMfaEnrollment enrollment;
+  final String submitLabel;
+  final Future<void> Function(String code) onSubmit;
+
+  @override
+  State<MfaEnrollmentForm> createState() => _MfaEnrollmentFormState();
+}
+
+class _MfaEnrollmentFormState extends State<MfaEnrollmentForm> {
+  final _codeController = TextEditingController();
+  bool _submitting = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _codeController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Center(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: SvgPicture.string(
+                Uri.decodeFull(
+                  widget.enrollment.qrCode.replaceFirst(
+                    'data:image/svg+xml;utf-8,',
+                    '',
+                  ),
+                ),
+                width: 220,
+                height: 220,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        const Text('Scan the QR code in your authenticator app.'),
+        const SizedBox(height: 8),
+        const Text('Manual setup key'),
+        const SizedBox(height: 4),
+        SelectableText(
+          widget.enrollment.secret,
+          style: const TextStyle(fontFamily: 'monospace'),
+        ),
+        const SizedBox(height: 16),
+        _MfaCodeInput(controller: _codeController),
+        if (_error != null) ...[
+          const SizedBox(height: 12),
+          Text(
+            _error!,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ],
+        const SizedBox(height: 16),
+        FilledButton.icon(
+          onPressed: _submitting ? null : _submit,
+          icon: _submitting
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.verified_user_outlined),
+          label: Text(widget.submitLabel),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _submit() async {
+    final code = _codeController.text.trim();
+    if (code.length != 6) {
+      return;
+    }
+    setState(() => _submitting = true);
+    try {
+      await widget.onSubmit(code);
+    } catch (error) {
+      if (mounted) {
+        setState(() => _error = error.toString());
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _submitting = false);
+      }
+    }
+  }
+}
+
+class MfaChallengeForm extends StatefulWidget {
+  const MfaChallengeForm({
+    super.key,
+    required this.onSubmit,
+  });
+
+  final Future<void> Function(String code) onSubmit;
+
+  @override
+  State<MfaChallengeForm> createState() => _MfaChallengeFormState();
+}
+
+class _MfaChallengeFormState extends State<MfaChallengeForm> {
+  final _codeController = TextEditingController();
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _codeController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _MfaCodeInput(controller: _codeController),
+        const SizedBox(height: 16),
+        FilledButton.icon(
+          onPressed: _submitting ? null : _submit,
+          icon: _submitting
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.lock_open_rounded),
+          label: const Text('Verify and continue'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _submit() async {
+    final code = _codeController.text.trim();
+    if (code.length != 6) {
+      return;
+    }
+    setState(() => _submitting = true);
+    try {
+      await widget.onSubmit(code);
+    } finally {
+      if (mounted) {
+        setState(() => _submitting = false);
+      }
+    }
+  }
+}
+
+class _MfaCodeInput extends StatelessWidget {
+  const _MfaCodeInput({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Pinput(
+        controller: controller,
+        length: 6,
+        keyboardType: TextInputType.number,
+        autofocus: true,
+        closeKeyboardWhenCompleted: true,
+      ),
+    );
+  }
+}
+
+class _EnrollmentLoading extends StatelessWidget {
+  const _EnrollmentLoading({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasError = context.watch<AuthCubit>().state.error != null;
+    if (hasError) {
+      return OutlinedButton.icon(
+        onPressed: onRetry,
+        icon: const Icon(Icons.refresh_rounded),
+        label: const Text('Try setup again'),
+      );
+    }
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(24),
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}

--- a/lib/screens/privacy_policy_page.dart
+++ b/lib/screens/privacy_policy_page.dart
@@ -64,6 +64,7 @@ class PrivacyPolicyPage extends StatelessWidget {
                       '''NotelyTask keeps data collection limited to the app experience:
 
 • **Account Information**: Your account service stores your email address and password credentials for login
+• **Two-Factor Authentication**: Your account service stores authenticator-app factor metadata for required sign-in verification
 • **Synced Notes**: Your notes are stored as one per-user note document in cloud storage
 • **Attachments**: Files you attach to notes are stored in private cloud storage
 • **Local Cache**: Notes are also cached locally on your device for offline use
@@ -78,6 +79,7 @@ class PrivacyPolicyPage extends StatelessWidget {
 
 • **Email Login**: You create and access your account with email and password
 • **Email Confirmation**: New accounts require email confirmation
+• **Two-Factor Authentication**: Cloud notes and attachments require an authenticator-app code after login
 • **Password Reset**: Password reset links are sent by email
 • **Offline Editing**: Text notes are cached locally and can be edited while offline
 • **Cloud Sync**: Local note changes sync to your cloud account when the app can connect''',
@@ -86,8 +88,8 @@ class PrivacyPolicyPage extends StatelessWidget {
                       context,
                       'Data Storage and Security',
                       '''• **Account Security**: Passwords are handled by the account service, not stored directly by the app
-• **Access Controls**: Cloud database policies restrict each user to their own note document
-• **Private Storage**: Attachment storage is scoped to the signed-in user
+• **Access Controls**: Cloud database policies restrict each user to their own note document and require completed two-factor authentication
+• **Private Storage**: Attachment storage is scoped to the signed-in user and requires completed two-factor authentication
 • **PIN Encryption**: When enabled, your note document is encrypted before it is synced
 • **Local Cache**: Your device keeps an offline copy of notes for app functionality
 • **Device Security**: Local cache security also depends on your device security''',
@@ -95,7 +97,7 @@ class PrivacyPolicyPage extends StatelessWidget {
                     _buildSection(
                       context,
                       'Cloud Services',
-                      '''NotelyTask uses a cloud provider for authentication, database storage, file storage, and email delivery for account flows. The provider processes the information required to provide these services, including account email, authentication metadata, note document storage, and attachment storage.''',
+                      '''NotelyTask uses a cloud provider for authentication, two-factor authentication, database storage, file storage, and email delivery for account flows. The provider processes the information required to provide these services, including account email, authentication metadata, note document storage, and attachment storage.''',
                     ),
                     _buildSection(
                       context,

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -9,6 +9,7 @@ import 'package:notelytask/models/notes_state.dart';
 import 'package:notelytask/models/settings_state.dart';
 import 'package:notelytask/models/sync_state.dart';
 import 'package:notelytask/service/navigation_service.dart';
+import 'package:notelytask/screens/mfa_page.dart';
 import 'package:notelytask/theme.dart';
 import 'package:notelytask/utils.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -22,6 +23,7 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   String version = '';
+  bool _mfaBusy = false;
 
   Future<String> getVersion() async {
     final packageInfo = await PackageInfo.fromPlatform();
@@ -88,6 +90,10 @@ class _SettingsPageState extends State<SettingsPage> {
             const SizedBox(height: 12),
             _buildSyncCard(colorScheme: colorScheme),
             const SizedBox(height: 24),
+            _buildSectionHeader(context, 'Security'),
+            const SizedBox(height: 12),
+            _buildSecurityCard(colorScheme: colorScheme),
+            const SizedBox(height: 24),
             _buildSectionHeader(context, 'Appearance'),
             const SizedBox(height: 12),
             _ThemeCard(colorScheme: colorScheme),
@@ -100,6 +106,84 @@ class _SettingsPageState extends State<SettingsPage> {
         ),
       ),
     );
+  }
+
+  Future<void> _addAuthenticator() async {
+    final authCubit = context.read<AuthCubit>();
+    setState(() => _mfaBusy = true);
+    AuthMfaEnrollment? enrollment;
+    try {
+      enrollment = await authCubit.createTotpEnrollment();
+      if (!mounted) return;
+      final verified = await showDialog<bool>(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => MfaEnrollmentDialog(enrollment: enrollment!),
+      );
+      if (verified != true) {
+        await authCubit.cancelTotpEnrollment(enrollment);
+      }
+      if (!mounted) return;
+      if (verified == true) {
+        showSnackBar(context, 'Authenticator added.');
+      }
+    } catch (error) {
+      if (!mounted) return;
+      showSnackBar(context, error.toString());
+      if (enrollment != null) {
+        await authCubit.cancelTotpEnrollment(enrollment);
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _mfaBusy = false);
+      }
+    }
+  }
+
+  Future<void> _removeAuthenticator(String factorId) async {
+    final authCubit = context.read<AuthCubit>();
+    if (authCubit.state.mfaFactors.length <= 1) {
+      showSnackBar(
+        context,
+        'Add another authenticator before removing this one.',
+      );
+      return;
+    }
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Remove authenticator?'),
+        content: const Text(
+          'This authenticator will no longer work for sign-in codes.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) {
+      return;
+    }
+    setState(() => _mfaBusy = true);
+    try {
+      await authCubit.unenrollFactor(factorId);
+      if (!mounted) return;
+      showSnackBar(context, 'Authenticator removed.');
+    } catch (error) {
+      if (!mounted) return;
+      showSnackBar(context, error.toString());
+    } finally {
+      if (mounted) {
+        setState(() => _mfaBusy = false);
+      }
+    }
   }
 
   Widget _buildSyncCard({required ColorScheme colorScheme}) {
@@ -228,6 +312,102 @@ class _SettingsPageState extends State<SettingsPage> {
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildSecurityCard({required ColorScheme colorScheme}) {
+    return BlocBuilder<AuthCubit, AuthState>(
+      builder: (context, authState) {
+        final factors = authState.mfaFactors;
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Row(
+                  children: [
+                    CircleAvatar(
+                      radius: 20,
+                      backgroundColor: colorScheme.secondary,
+                      child: Icon(
+                        Icons.verified_user_rounded,
+                        color: colorScheme.onSecondary,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Two-factor authentication',
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleMedium
+                                ?.copyWith(fontWeight: FontWeight.w600),
+                          ),
+                          Text(
+                            'Required for cloud notes and attachments',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(
+                                  color: colorScheme.onSurfaceVariant,
+                                ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                if (factors.isEmpty)
+                  const Text('No verified authenticator is available.')
+                else
+                  ...factors.map(
+                    (factor) => ListTile(
+                      contentPadding: EdgeInsets.zero,
+                      leading: const Icon(Icons.password_rounded),
+                      title: Text(
+                        factor.friendlyName?.isNotEmpty == true
+                            ? factor.friendlyName!
+                            : 'Authenticator app',
+                      ),
+                      subtitle: Text(
+                        'Added ${factor.createdAt.toLocal().toString().split(".").first}',
+                      ),
+                      trailing: IconButton(
+                        tooltip: factors.length <= 1
+                            ? 'Add another authenticator before removing this one'
+                            : 'Remove authenticator',
+                        onPressed: _mfaBusy || factors.length <= 1
+                            ? null
+                            : () => _removeAuthenticator(factor.id),
+                        icon: const Icon(Icons.delete_outline_rounded),
+                      ),
+                    ),
+                  ),
+                const SizedBox(height: 8),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    onPressed: _mfaBusy ? null : _addAuthenticator,
+                    icon: _mfaBusy
+                        ? const SizedBox(
+                            height: 18,
+                            width: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.add_moderator_outlined),
+                    label: const Text('Add Authenticator'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -596,7 +596,7 @@ packages:
     source: hosted
     version: "4.1.0"
   flutter_svg:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_svg
       sha256: "87fbd7c534435b6c5d9d98b01e1fd527812b82e68ddd8bd35fc45ed0fa8f0a95"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   pinput: ^5.0.0
   flutter_quill: ^11.5.1
   google_fonts: ^6.0.0
+  flutter_svg: ^2.2.3
   flutter_widget_from_html: ^0.15.3
   http_parser: ^4.0.2
   flutter_secure_storage: ^10.3.1

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -300,8 +300,8 @@ max_enrolled_factors = 10
 
 # Control MFA via App Authenticator (TOTP)
 [auth.mfa.totp]
-enroll_enabled = false
-verify_enabled = false
+enroll_enabled = true
+verify_enabled = true
 
 # Configure MFA via Phone Messaging
 [auth.mfa.phone]

--- a/supabase/migrations/20260608090000_require_aal2_for_notes_and_attachments.sql
+++ b/supabase/migrations/20260608090000_require_aal2_for_notes_and_attachments.sql
@@ -1,0 +1,72 @@
+create policy "MFA is required to read note documents"
+on public.note_documents
+as restrictive
+for select
+to authenticated
+using ((select auth.jwt() ->> 'aal') = 'aal2');
+
+create policy "MFA is required to insert note documents"
+on public.note_documents
+as restrictive
+for insert
+to authenticated
+with check ((select auth.jwt() ->> 'aal') = 'aal2');
+
+create policy "MFA is required to update note documents"
+on public.note_documents
+as restrictive
+for update
+to authenticated
+using ((select auth.jwt() ->> 'aal') = 'aal2')
+with check ((select auth.jwt() ->> 'aal') = 'aal2');
+
+create policy "MFA is required to delete note documents"
+on public.note_documents
+as restrictive
+for delete
+to authenticated
+using ((select auth.jwt() ->> 'aal') = 'aal2');
+
+create policy "MFA is required to read attachments"
+on storage.objects
+as restrictive
+for select
+to authenticated
+using (
+  bucket_id <> 'note-attachments'
+  or (select auth.jwt() ->> 'aal') = 'aal2'
+);
+
+create policy "MFA is required to upload attachments"
+on storage.objects
+as restrictive
+for insert
+to authenticated
+with check (
+  bucket_id <> 'note-attachments'
+  or (select auth.jwt() ->> 'aal') = 'aal2'
+);
+
+create policy "MFA is required to update attachments"
+on storage.objects
+as restrictive
+for update
+to authenticated
+using (
+  bucket_id <> 'note-attachments'
+  or (select auth.jwt() ->> 'aal') = 'aal2'
+)
+with check (
+  bucket_id <> 'note-attachments'
+  or (select auth.jwt() ->> 'aal') = 'aal2'
+);
+
+create policy "MFA is required to delete attachments"
+on storage.objects
+as restrictive
+for delete
+to authenticated
+using (
+  bucket_id <> 'note-attachments'
+  or (select auth.jwt() ->> 'aal') = 'aal2'
+);


### PR DESCRIPTION
## Summary
- require authenticator-app MFA before the app treats a session as fully authenticated
- add required MFA setup/challenge UI and Settings authenticator management
- enable Supabase TOTP config and add AAL2 RLS policies for note documents and attachments
- update README, privacy text, and AGENTS guidance

## Verification
- flutter analyze
- flutter test
- flutter build web --release with production Supabase dart-defines
- supabase config push --yes
- supabase db push --linked
- supabase migration list --linked
- firebase deploy --only hosting:notelytask --project deniz-bilgin

## Deploy
- Firebase Hosting deployed successfully for site notelytask-edd7f