### PR TITLE
Add account deletion flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,13 @@ The app does not use the old local-folder sync backend anymore. Notes sync to Su
 - First login/sync must preserve the local-versus-cloud conflict prompt instead of silently overwriting either side.
 - The missing-PIN decrypt prompt in `NotesCubit` must remain single-flight. Auth, home mount, settings, and native/widget paths can overlap sync requests, and only one decrypt dialog should appear.
 
+## Auth and Entry Routes
+
+- Logged-out `/` shows the cross-platform landing page. Do not route logged-out users directly to the auth form from `/`.
+- `/login` and `/signup` are the dedicated auth entry routes and set the initial auth form mode.
+- Authenticated users bypass the landing page and go straight to notes; MFA-required and password-recovery sessions continue through their dedicated auth/MFA flows.
+- `/auth-callback` remains reserved for email confirmation, password reset, and Supabase auth callback handling.
+
 ## Encryption Rules
 
 - PIN encryption is still supported for the synced note blob.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ The app does not use the old local-folder sync backend anymore. Notes sync to Su
 - Do not split notes into relational rows unless the product direction explicitly changes.
 - Supabase Storage bucket `note-attachments` stores attachment bytes under the signed-in user's id prefix.
 - Attachment metadata remains inside the note blob.
+- Account deletion is initiated from Settings. It must remove the user's Storage attachments, note document, Supabase auth user, local note cache, selected-note state, and remembered local PIN.
 - Local text edits should update immediately and mark remote sync dirty if Supabase write fails.
 - Cloud note and attachment access requires a Supabase `aal2` session; email/password-only `aal1` sessions must stay in the MFA gate and must not trigger sync.
 - First login/sync must preserve the local-versus-cloud conflict prompt instead of silently overwriting either side.
@@ -58,6 +59,7 @@ The app does not use the old local-folder sync backend anymore. Notes sync to Su
 - The Supabase CLI uses `SUPABASE_ACCESS_TOKEN` in the user's shell for remote operations.
 - Apply migrations only after linking the intended project; never commit service-role keys.
 - TOTP MFA must stay enabled in Supabase config, and note/document Storage RLS must keep requiring `auth.jwt()->>'aal' = 'aal2'` for the app's private data surfaces.
+- `delete_current_user_account` is a security-definer RPC for account deletion. It requires an authenticated `aal2` session and deletes only the current user's private app data before removing the auth user.
 - Email confirmation and password reset require Supabase Auth redirect URLs for `https://notelytask.dbilgin.com/auth-callback` and `com.omedacore.notelytask://auth-callback`.
 - Firebase Hosting uses project `deniz-bilgin`, hosting target `notelytask`, and site `notelytask-edd7f`.
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ The auth flow supports:
 - Required authenticator-app two-factor authentication
 - Password reset by email
 - Sign out
+- Account deletion from Settings
 
 Cloud note and attachment access requires an `aal2` Supabase session. After email/password login, existing users must verify a TOTP code or set up an authenticator app before cloud sync starts.
+
+Deleting an account removes the user's synced note document, private attachment files, auth account, local note cache, and remembered local encryption PIN on that device.
 
 ### Encryption
 

--- a/lib/cubit/auth_cubit.dart
+++ b/lib/cubit/auth_cubit.dart
@@ -81,6 +81,15 @@ class AuthCubit extends Cubit<AuthState> {
     });
   }
 
+  Future<void> clearDeletedAccountSession() async {
+    try {
+      await _requireClient().auth.signOut();
+    } catch (_) {
+      // The auth user has already been removed server-side.
+    }
+    emit(const AuthState.unauthenticated(message: 'Account deleted.'));
+  }
+
   Future<void> sendPasswordReset(String email) async {
     await _runAuthAction(() async {
       await _requireClient().auth.resetPasswordForEmail(

--- a/lib/cubit/supabase_sync_cubit.dart
+++ b/lib/cubit/supabase_sync_cubit.dart
@@ -176,6 +176,36 @@ class SupabaseSyncCubit extends Cubit<SyncState> {
     }
   }
 
+  Future<bool> deleteAccountData() async {
+    if (!isConnected()) {
+      emit(
+        state.copyWith(
+          loading: false,
+          error: true,
+          message: 'Sign in before deleting your account.',
+        ),
+      );
+      return false;
+    }
+
+    emit(state.copyWith(loading: true, error: false, clearMessage: true));
+    try {
+      await syncRepository!.deleteAllAttachments();
+      await syncRepository!.deleteAccountData();
+      emit(state.copyWith(loading: false, error: false, dirty: false));
+      return true;
+    } catch (error) {
+      emit(
+        state.copyWith(
+          loading: false,
+          error: true,
+          message: error.toString(),
+        ),
+      );
+      return false;
+    }
+  }
+
   void markDirty() {
     emit(state.copyWith(dirty: true));
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:notelytask/screens/auth_callback_page.dart';
 import 'package:notelytask/screens/auth_page.dart';
 import 'package:notelytask/screens/details_page.dart';
 import 'package:notelytask/screens/home_page.dart';
+import 'package:notelytask/screens/landing_page.dart';
 import 'package:notelytask/cubit/notes_cubit.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:notelytask/screens/privacy_policy_page.dart';
@@ -91,6 +92,12 @@ class App extends StatelessWidget {
 
               var routes = <String, WidgetBuilder>{
                 '/': (context) => const AuthGate(),
+                '/login': (context) => const AuthEntryGate(
+                      initialMode: AuthFormMode.signIn,
+                    ),
+                '/signup': (context) => const AuthEntryGate(
+                      initialMode: AuthFormMode.signUp,
+                    ),
                 '/auth-callback': (context) => const AuthCallbackPage(),
                 '/deleted_list': (context) => const DeletedListPage(),
                 '/details': (context) => Scaffold(
@@ -154,7 +161,46 @@ class AuthGate extends StatelessWidget {
           return const HomePage();
         }
 
-        return const AuthPage();
+        if (state.status == AuthStatus.mfaEnrollmentRequired ||
+            state.status == AuthStatus.mfaVerificationRequired ||
+            state.status == AuthStatus.passwordRecovery) {
+          return const AuthPage();
+        }
+
+        return const LandingPage();
+      },
+    );
+  }
+}
+
+class AuthEntryGate extends StatelessWidget {
+  const AuthEntryGate({
+    super.key,
+    required this.initialMode,
+  });
+
+  final AuthFormMode initialMode;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<AuthCubit, AuthState>(
+      listener: (context, state) {
+        if (state.status == AuthStatus.authenticated) {
+          context.read<NotesCubit>().getAndUpdateLocalNotes(context: context);
+        }
+      },
+      builder: (context, state) {
+        if (state.status == AuthStatus.loading) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+
+        if (state.status == AuthStatus.authenticated) {
+          return const HomePage();
+        }
+
+        return AuthPage(initialMode: initialMode);
       },
     );
   }

--- a/lib/repository/supabase_sync_repository.dart
+++ b/lib/repository/supabase_sync_repository.dart
@@ -87,4 +87,26 @@ class SupabaseSyncRepository {
   Future<void> deleteAttachment(String path) async {
     await client.storage.from(attachmentBucket).remove([path]);
   }
+
+  Future<void> deleteAllAttachments() async {
+    final storage = client.storage.from(attachmentBucket);
+
+    while (true) {
+      final files = await storage.list(
+        path: _userId,
+        searchOptions: const SearchOptions(limit: 100),
+      );
+      if (files.isEmpty) {
+        return;
+      }
+
+      await storage.remove(
+        files.map((file) => '$_userId/${file.name}').toList(),
+      );
+    }
+  }
+
+  Future<void> deleteAccountData() async {
+    await client.rpc('delete_current_user_account');
+  }
 }

--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -7,7 +7,12 @@ import 'package:notelytask/screens/mfa_page.dart';
 enum AuthFormMode { signIn, signUp, resetRequest, updatePassword }
 
 class AuthPage extends StatefulWidget {
-  const AuthPage({super.key});
+  const AuthPage({
+    super.key,
+    this.initialMode = AuthFormMode.signIn,
+  });
+
+  final AuthFormMode initialMode;
 
   @override
   State<AuthPage> createState() => _AuthPageState();
@@ -18,7 +23,21 @@ class _AuthPageState extends State<AuthPage> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   final _confirmPasswordController = TextEditingController();
-  AuthFormMode _mode = AuthFormMode.signIn;
+  late AuthFormMode _mode;
+
+  @override
+  void initState() {
+    super.initState();
+    _mode = widget.initialMode;
+  }
+
+  @override
+  void didUpdateWidget(AuthPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.initialMode != oldWidget.initialMode) {
+      _mode = widget.initialMode;
+    }
+  }
 
   @override
   void dispose() {

--- a/lib/screens/landing_page.dart
+++ b/lib/screens/landing_page.dart
@@ -1,0 +1,777 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:notelytask/theme.dart';
+
+class LandingPage extends StatelessWidget {
+  const LandingPage({super.key});
+
+  void _openLogin(BuildContext context) =>
+      Navigator.of(context).pushNamed('/login');
+  void _openSignup(BuildContext context) =>
+      Navigator.of(context).pushNamed('/signup');
+  void _openPrivacy(BuildContext context) =>
+      Navigator.of(context).pushNamed('/privacy_policy');
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final width = constraints.maxWidth;
+          final height = constraints.maxHeight;
+          final isCompact = width < 720;
+          final heroHeight = isCompact
+              ? math.max(560.0, height * 0.86)
+              : math.max(600.0, height * 0.78);
+
+          return SingleChildScrollView(
+            child: Column(
+              children: [
+                _HeroSection(
+                  height: heroHeight,
+                  isCompact: isCompact,
+                  onLogin: () => _openLogin(context),
+                  onSignup: () => _openSignup(context),
+                  onPrivacy: () => _openPrivacy(context),
+                ),
+                _FeatureBand(isCompact: isCompact),
+                _SecurityBand(isCompact: isCompact),
+                _Footer(
+                  theme: theme,
+                  onLogin: () => _openLogin(context),
+                  onSignup: () => _openSignup(context),
+                  onPrivacy: () => _openPrivacy(context),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _HeroSection extends StatelessWidget {
+  const _HeroSection({
+    required this.height,
+    required this.isCompact,
+    required this.onLogin,
+    required this.onSignup,
+    required this.onPrivacy,
+  });
+
+  final double height;
+  final bool isCompact;
+  final VoidCallback onLogin;
+  final VoidCallback onSignup;
+  final VoidCallback onPrivacy;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return SizedBox(
+      height: height,
+      width: double.infinity,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          const _HeroBitmapBackdrop(),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  colorScheme.surface.withValues(alpha: 0.05),
+                  colorScheme.surface.withValues(alpha: 0.42),
+                  colorScheme.surface.withValues(alpha: 0.92),
+                ],
+              ),
+            ),
+          ),
+          SafeArea(
+            bottom: false,
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(
+                isCompact ? 20 : 48,
+                18,
+                isCompact ? 20 : 48,
+                32,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _LandingNav(
+                    isCompact: isCompact,
+                    onLogin: onLogin,
+                    onSignup: onSignup,
+                    onPrivacy: onPrivacy,
+                  ),
+                  const Spacer(),
+                  Align(
+                    alignment:
+                        isCompact ? Alignment.bottomLeft : Alignment.centerLeft,
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(
+                        maxWidth: isCompact ? 520 : 720,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'NotelyTask',
+                            style: theme.textTheme.displayLarge?.copyWith(
+                              fontSize: isCompact ? 54 : 82,
+                              height: 0.95,
+                              fontWeight: FontWeight.w800,
+                              letterSpacing: 0,
+                              color: colorScheme.onSurface,
+                            ),
+                          ),
+                          const SizedBox(height: 18),
+                          Text(
+                            'Private notes that stay quick offline, sync when you are ready, and protect your account with two-factor sign-in.',
+                            style: theme.textTheme.titleLarge?.copyWith(
+                              height: 1.35,
+                              color: colorScheme.onSurface.withValues(
+                                alpha: 0.86,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 28),
+                          Wrap(
+                            spacing: 12,
+                            runSpacing: 12,
+                            children: [
+                              FilledButton.icon(
+                                onPressed: onSignup,
+                                icon: const Icon(Icons.person_add_rounded),
+                                label: const Text('Create account'),
+                              ),
+                              OutlinedButton.icon(
+                                onPressed: onLogin,
+                                icon: const Icon(Icons.login_rounded),
+                                label: const Text('Sign in'),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const Spacer(),
+                  _HeroStats(isCompact: isCompact),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeroBitmapBackdrop extends StatelessWidget {
+  const _HeroBitmapBackdrop();
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return ColoredBox(
+      color: colorScheme.surface,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          Image.asset(
+            'assets/foreground.png',
+            fit: BoxFit.cover,
+            opacity: const AlwaysStoppedAnimation(0.18),
+            errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+          ),
+          Image.asset(
+            'assets/icon.png',
+            fit: BoxFit.none,
+            alignment: const Alignment(0.78, -0.18),
+            scale: 0.68,
+            opacity: const AlwaysStoppedAnimation(0.2),
+            errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+          ),
+          const _EditorialOverlay(),
+        ],
+      ),
+    );
+  }
+}
+
+class _EditorialOverlay extends StatelessWidget {
+  const _EditorialOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(painter: _EditorialPainter(Theme.of(context)));
+  }
+}
+
+class _EditorialPainter extends CustomPainter {
+  const _EditorialPainter(this.theme);
+
+  final ThemeData theme;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final surface = theme.colorScheme.surface;
+    final primary = theme.colorScheme.primary;
+    final secondary = theme.colorScheme.secondary;
+    final success =
+        ThemeHelper.getThemeColors(AppTheme.forestGreen)['primary']!;
+    final warning = AppColors.warning;
+
+    final washPaint = Paint()
+      ..shader = LinearGradient(
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+        colors: [
+          primary.withValues(alpha: 0.34),
+          success.withValues(alpha: 0.18),
+          warning.withValues(alpha: 0.16),
+        ],
+      ).createShader(Offset.zero & size);
+    canvas.drawRect(Offset.zero & size, washPaint);
+
+    final notePaint = Paint()
+      ..color = surface.withValues(alpha: 0.72)
+      ..style = PaintingStyle.fill;
+    final strokePaint = Paint()
+      ..color = Colors.white.withValues(alpha: 0.12)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.2;
+    final linePaint = Paint()
+      ..color = Colors.white.withValues(alpha: 0.2)
+      ..strokeWidth = 3
+      ..strokeCap = StrokeCap.round;
+    final accentPaint = Paint()
+      ..color = secondary.withValues(alpha: 0.56)
+      ..strokeWidth = 4
+      ..strokeCap = StrokeCap.round;
+
+    final baseX = size.width * 0.58;
+    final baseY = size.height * 0.18;
+    for (var i = 0; i < 4; i++) {
+      final rect = RRect.fromRectAndRadius(
+        Rect.fromLTWH(
+          baseX + i * 34,
+          baseY + i * 76,
+          math.min(310, size.width * 0.34),
+          145,
+        ),
+        const Radius.circular(8),
+      );
+      canvas.save();
+      canvas.translate(rect.outerRect.center.dx, rect.outerRect.center.dy);
+      canvas.rotate((-5 + i * 2.7) * math.pi / 180);
+      canvas.translate(-rect.outerRect.center.dx, -rect.outerRect.center.dy);
+      canvas.drawRRect(rect, notePaint);
+      canvas.drawRRect(rect, strokePaint);
+      final left = rect.outerRect.left + 24;
+      final top = rect.outerRect.top + 28;
+      canvas.drawLine(Offset(left, top), Offset(left + 128, top), accentPaint);
+      canvas.drawLine(
+        Offset(left, top + 34),
+        Offset(left + 218, top + 34),
+        linePaint,
+      );
+      canvas.drawLine(
+        Offset(left, top + 64),
+        Offset(left + 170, top + 64),
+        linePaint,
+      );
+      canvas.restore();
+    }
+
+    final pathPaint = Paint()
+      ..color = primary.withValues(alpha: 0.26)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+    final path = Path()
+      ..moveTo(size.width * 0.04, size.height * 0.72)
+      ..cubicTo(
+        size.width * 0.26,
+        size.height * 0.42,
+        size.width * 0.58,
+        size.height * 0.8,
+        size.width * 0.96,
+        size.height * 0.52,
+      );
+    canvas.drawPath(path, pathPaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _EditorialPainter oldDelegate) =>
+      oldDelegate.theme != theme;
+}
+
+class _LandingNav extends StatelessWidget {
+  const _LandingNav({
+    required this.isCompact,
+    required this.onLogin,
+    required this.onSignup,
+    required this.onPrivacy,
+  });
+
+  final bool isCompact;
+  final VoidCallback onLogin;
+  final VoidCallback onSignup;
+  final VoidCallback onPrivacy;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Row(
+      children: [
+        Image.asset(
+          'assets/icon.png',
+          width: 34,
+          height: 34,
+          errorBuilder: (_, __, ___) => const Icon(Icons.note_alt_rounded),
+        ),
+        const SizedBox(width: 10),
+        Text(
+          'NotelyTask',
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        const Spacer(),
+        if (!isCompact)
+          TextButton(
+            onPressed: onPrivacy,
+            child: const Text('Privacy'),
+          ),
+        const SizedBox(width: 4),
+        TextButton(
+          onPressed: onLogin,
+          child: const Text('Sign in'),
+        ),
+        if (!isCompact) ...[
+          const SizedBox(width: 8),
+          FilledButton(
+            onPressed: onSignup,
+            child: const Text('Create account'),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _HeroStats extends StatelessWidget {
+  const _HeroStats({required this.isCompact});
+
+  final bool isCompact;
+
+  @override
+  Widget build(BuildContext context) {
+    final items = [
+      ('Offline first', Icons.offline_bolt_outlined),
+      ('Private cloud sync', Icons.cloud_done_outlined),
+      ('PIN encryption', Icons.enhanced_encryption_outlined),
+      ('Two-factor sign-in', Icons.verified_user_outlined),
+    ];
+
+    return Wrap(
+      spacing: 10,
+      runSpacing: 10,
+      children: items
+          .map(
+            (item) => _SignalPill(
+              label: item.$1,
+              icon: item.$2,
+              dense: isCompact,
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+class _SignalPill extends StatelessWidget {
+  const _SignalPill({
+    required this.label,
+    required this.icon,
+    required this.dense,
+  });
+
+  final String label;
+  final IconData icon;
+  final bool dense;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colorScheme.surface.withValues(alpha: 0.78),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: colorScheme.onSurface.withValues(alpha: 0.12),
+        ),
+      ),
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: dense ? 10 : 14,
+          vertical: dense ? 8 : 10,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: dense ? 16 : 18),
+            const SizedBox(width: 8),
+            Text(label),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FeatureBand extends StatelessWidget {
+  const _FeatureBand({required this.isCompact});
+
+  final bool isCompact;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final width = MediaQuery.sizeOf(context).width;
+    final crossAxisCount = width < 720
+        ? 1
+        : width < 1060
+            ? 2
+            : 4;
+    final features = [
+      _FeatureCopy(
+        icon: Icons.edit_note_rounded,
+        title: 'Write offline, sync later',
+        body:
+            'Keep writing when the connection drops. Your local cache stays fast, then sync catches up when the cloud is reachable.',
+      ),
+      _FeatureCopy(
+        icon: Icons.cloud_queue_rounded,
+        title: 'One private cloud note document',
+        body:
+            'Your notes move as a single private document for your account, with attachments stored separately in private storage.',
+      ),
+      _FeatureCopy(
+        icon: Icons.attach_file_rounded,
+        title: 'Attachments without folder setup',
+        body:
+            'Add images and files to notes without choosing device folders or managing sync directories by hand.',
+      ),
+      _FeatureCopy(
+        icon: Icons.lock_person_rounded,
+        title: 'PIN encryption and 2FA',
+        body:
+            'Encrypt your synced notes with a local PIN and protect account access with an authenticator app.',
+      ),
+    ];
+
+    return ColoredBox(
+      color: theme.colorScheme.surface,
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 1180),
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(
+              isCompact ? 20 : 48,
+              isCompact ? 42 : 70,
+              isCompact ? 20 : 48,
+              isCompact ? 26 : 50,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'A notes app with a longer memory.',
+                  style: theme.textTheme.headlineMedium?.copyWith(
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  'Quiet, practical tools for notes that need to travel with you without giving up privacy.',
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 28),
+                GridView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: features.length,
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: crossAxisCount,
+                    mainAxisSpacing: 14,
+                    crossAxisSpacing: 14,
+                    mainAxisExtent: isCompact ? 222 : 246,
+                  ),
+                  itemBuilder: (context, index) =>
+                      _FeatureTile(feature: features[index]),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SecurityBand extends StatelessWidget {
+  const _SecurityBand({required this.isCompact});
+
+  final bool isCompact;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return ColoredBox(
+      color: colorScheme.surfaceContainerHigh.withValues(alpha: 0.34),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 1180),
+          child: Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: isCompact ? 20 : 48,
+              vertical: isCompact ? 40 : 64,
+            ),
+            child: isCompact
+                ? const Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _SecurityCopy(),
+                      SizedBox(height: 24),
+                      _SecurityList(),
+                    ],
+                  )
+                : const Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(flex: 3, child: _SecurityCopy()),
+                      SizedBox(width: 36),
+                      Expanded(flex: 2, child: _SecurityList()),
+                    ],
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SecurityCopy extends StatelessWidget {
+  const _SecurityCopy();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Secure by habit, not by ceremony.',
+          style: theme.textTheme.headlineMedium?.copyWith(
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Account access requires two-factor authentication, while optional PIN encryption protects the synced note document before it leaves the device.',
+          style: theme.textTheme.bodyLarge?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+            height: 1.45,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SecurityList extends StatelessWidget {
+  const _SecurityList();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      children: [
+        _SecurityRow(
+          icon: Icons.verified_user_rounded,
+          title: 'Authenticator-app sign-in',
+        ),
+        _SecurityRow(
+          icon: Icons.lock_rounded,
+          title: 'Optional PIN-encrypted sync',
+        ),
+        _SecurityRow(
+          icon: Icons.folder_off_rounded,
+          title: 'No folder selection required',
+        ),
+      ],
+    );
+  }
+}
+
+class _Footer extends StatelessWidget {
+  const _Footer({
+    required this.theme,
+    required this.onLogin,
+    required this.onSignup,
+    required this.onPrivacy,
+  });
+
+  final ThemeData theme;
+  final VoidCallback onLogin;
+  final VoidCallback onSignup;
+  final VoidCallback onPrivacy;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: theme.colorScheme.surface,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 28),
+        child: Wrap(
+          alignment: WrapAlignment.center,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          spacing: 12,
+          runSpacing: 8,
+          children: [
+            Text(
+              'NotelyTask',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            TextButton(onPressed: onPrivacy, child: const Text('Privacy')),
+            TextButton(onPressed: onLogin, child: const Text('Sign in')),
+            FilledButton(
+              onPressed: onSignup,
+              child: const Text('Create account'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FeatureCopy {
+  const _FeatureCopy({
+    required this.icon,
+    required this.title,
+    required this.body,
+  });
+
+  final IconData icon;
+  final String title;
+  final String body;
+}
+
+class _FeatureTile extends StatelessWidget {
+  const _FeatureTile({required this.feature});
+
+  final _FeatureCopy feature;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.56),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outline.withValues(alpha: 0.16)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(18),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(feature.icon, size: 28, color: colorScheme.primary),
+            const SizedBox(height: 14),
+            Text(
+              feature.title,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: Text(
+                feature.body,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                  height: 1.35,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SecurityRow extends StatelessWidget {
+  const _SecurityRow({
+    required this.icon,
+    required this.title,
+  });
+
+  final IconData icon;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        children: [
+          DecoratedBox(
+            decoration: BoxDecoration(
+              color: colorScheme.primary.withValues(alpha: 0.18),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(10),
+              child: Icon(icon, color: colorScheme.primary),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              title,
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/privacy_policy_page.dart
+++ b/lib/screens/privacy_policy_page.dart
@@ -103,9 +103,9 @@ class PrivacyPolicyPage extends StatelessWidget {
                       context,
                       'Data Retention',
                       '''• **Account Data**: Account data remains in the cloud service while your account exists
-• **Synced Notes**: Synced notes remain until you delete them or your account data is removed
+• **Synced Notes**: Synced notes remain until you delete them or delete your account
 • **Deleted Notes**: Deleted notes are moved to the app's deleted state and can be permanently removed
-• **Attachments**: Attachments remain in private storage until deleted
+• **Attachments**: Attachments remain in private storage until deleted or your account is deleted
 • **Local Cache**: Uninstalling the app removes local device data, but not cloud data already synced to your account''',
                     ),
                     _buildSection(
@@ -116,6 +116,7 @@ class PrivacyPolicyPage extends StatelessWidget {
 • Access all your data stored in the app
 • Export your notes at any time
 • Delete your notes and app data
+• Delete your account and synced cloud data from Settings
 • Sign out of your cloud account
 • Request information about data processing
 • Contact us with privacy concerns''',

--- a/lib/screens/privacy_policy_page.dart
+++ b/lib/screens/privacy_policy_page.dart
@@ -144,11 +144,7 @@ class PrivacyPolicyPage extends StatelessWidget {
                     _buildSection(
                       context,
                       'Contact Us',
-                      '''If you have questions about this Privacy Policy or our data practices:
-
-• **GitHub Issues**: Open an issue on our repository
-• **Source Code**: Review the app source code
-• **Cloud Provider**: Review the cloud provider's privacy and security documentation for platform-level processing''',
+                      '''If you have questions about this Privacy Policy or our data practices: support@omedacore.com''',
                     ),
                     const SizedBox(height: 24),
                     Container(

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -24,6 +24,7 @@ class SettingsPage extends StatefulWidget {
 class _SettingsPageState extends State<SettingsPage> {
   String version = '';
   bool _mfaBusy = false;
+  bool _deleteAccountBusy = false;
 
   Future<String> getVersion() async {
     final packageInfo = await PackageInfo.fromPlatform();
@@ -94,6 +95,10 @@ class _SettingsPageState extends State<SettingsPage> {
             const SizedBox(height: 12),
             _buildSecurityCard(colorScheme: colorScheme),
             const SizedBox(height: 24),
+            _buildSectionHeader(context, 'Account'),
+            const SizedBox(height: 12),
+            _buildAccountCard(colorScheme: colorScheme),
+            const SizedBox(height: 24),
             _buildSectionHeader(context, 'Appearance'),
             const SizedBox(height: 12),
             _ThemeCard(colorScheme: colorScheme),
@@ -138,6 +143,64 @@ class _SettingsPageState extends State<SettingsPage> {
         setState(() => _mfaBusy = false);
       }
     }
+  }
+
+  Future<void> _deleteAccount() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete account?'),
+        content: const Text(
+          'This permanently deletes your account, synced notes, attachments, '
+          'and local cached notes on this device. This cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+              foregroundColor: Theme.of(context).colorScheme.onError,
+            ),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete account'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) {
+      return;
+    }
+
+    final syncCubit = context.read<SupabaseSyncCubit>();
+    final notesCubit = context.read<NotesCubit>();
+    final settingsCubit = context.read<SettingsCubit>();
+    final authCubit = context.read<AuthCubit>();
+
+    setState(() => _deleteAccountBusy = true);
+    final deleted = await syncCubit.deleteAccountData();
+    if (!mounted) {
+      return;
+    }
+
+    if (!deleted) {
+      setState(() => _deleteAccountBusy = false);
+      showSnackBar(context, 'Account deletion failed. Please try again.');
+      return;
+    }
+
+    await notesCubit.clearEncryptionKey();
+    notesCubit.reset();
+    settingsCubit.setSelectedNoteId(null);
+    await authCubit.clearDeletedAccountSession();
+
+    if (!mounted) {
+      return;
+    }
+    setState(() => _deleteAccountBusy = false);
+    getIt<NavigationService>().pushNamed('/');
   }
 
   Future<void> _removeAuthenticator(String factorId) async {
@@ -408,6 +471,68 @@ class _SettingsPageState extends State<SettingsPage> {
           ),
         );
       },
+    );
+  }
+
+  Widget _buildAccountCard({required ColorScheme colorScheme}) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                CircleAvatar(
+                  radius: 20,
+                  backgroundColor: colorScheme.errorContainer,
+                  child: Icon(
+                    Icons.delete_forever_rounded,
+                    color: colorScheme.onErrorContainer,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Delete account',
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleMedium
+                            ?.copyWith(fontWeight: FontWeight.w600),
+                      ),
+                      Text(
+                        'Permanently remove your account, notes, and files',
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: _deleteAccountBusy ? null : _deleteAccount,
+              icon: _deleteAccountBusy
+                  ? const SizedBox(
+                      height: 18,
+                      width: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.delete_outline_rounded),
+              label: const Text('Delete Account'),
+              style: FilledButton.styleFrom(
+                backgroundColor: colorScheme.error,
+                foregroundColor: colorScheme.onError,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 

--- a/supabase/migrations/20260608120000_delete_current_user_account.sql
+++ b/supabase/migrations/20260608120000_delete_current_user_account.sql
@@ -1,0 +1,31 @@
+create or replace function public.delete_current_user_account()
+returns void
+language plpgsql
+security definer
+set search_path = public, auth, storage
+as $$
+declare
+  requesting_user uuid := auth.uid();
+begin
+  if requesting_user is null then
+    raise exception 'Not authenticated' using errcode = '28000';
+  end if;
+
+  if coalesce(auth.jwt() ->> 'aal', '') <> 'aal2' then
+    raise exception 'Two-factor authentication required' using errcode = '42501';
+  end if;
+
+  delete from storage.objects
+  where bucket_id = 'note-attachments'
+    and (storage.foldername(name))[1] = requesting_user::text;
+
+  delete from public.note_documents
+  where user_id = requesting_user;
+
+  delete from auth.users
+  where id = requesting_user;
+end;
+$$;
+
+revoke all on function public.delete_current_user_account() from public;
+grant execute on function public.delete_current_user_account() to authenticated;

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -14,12 +14,26 @@ void main() {
     }
   });
 
-  testWidgets('shows cloud sync configuration message when not configured',
+  testWidgets('shows landing page when logged out',
       (WidgetTester tester) async {
     await tester.pumpWidget(const App());
     await tester.pump();
 
-    expect(find.text('NotelyTask'), findsOneWidget);
+    expect(find.text('NotelyTask'), findsWidgets);
+    expect(
+      find.textContaining('Private notes'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('shows cloud sync configuration message on auth route',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const App());
+    await tester.pump();
+
+    await tester.tap(find.text('Sign in').first);
+    await tester.pumpAndSettle();
+
     expect(
       find.textContaining('Cloud sync is not configured'),
       findsOneWidget,


### PR DESCRIPTION
## Summary
- add Settings account deletion UI with confirmation and local cleanup
- add Supabase RPC migration to delete the current user's attachments, note document, and auth user
- document account deletion behavior in README, privacy policy, and AGENTS.md

## Verification
- flutter analyze
- flutter test
- flutter build web --release
- supabase db push --linked
- firebase deploy --only hosting:notelytask --project deniz-bilgin